### PR TITLE
add comment_count to article response

### DIFF
--- a/__tests__/integration/articles.test.js
+++ b/__tests__/integration/articles.test.js
@@ -101,23 +101,24 @@ describe("ENDPOINT: /api/articles", () => {
 describe("ENDPOINT: /api/articles/article:id", () => {
   describe("GET: /api/articles/article:id", () => {
     test("Returns a 200 OK status when an article is fetched successfully", async () => {
-      await request(app).get("/api/articles/2").expect(200);
+      await request(app).get("/api/articles/5").expect(200);
     });
 
-    test("Returns the article object when a valid id is provided", async () => {
+    test("Returns the article object with comment_count when a valid article_id is provided", async () => {
       const {
         body: {article},
-      } = await request(app).get("/api/articles/2").expect(200);
-      expect(article.article_id).toBe(2);
-      expect(article.title).toBe("Sony Vaio; or, The Laptop");
+      } = await request(app).get("/api/articles/1").expect(200);
+      expect(article.article_id).toBe(1);
+      expect(article.title).toBe("Living in the shadow of a great man");
       expect(article.topic).toBe("mitch");
-      expect(article.author).toBe("icellusedkars");
-      expect(article.body).toBe("Call me Mitchell. Some years ago..");
-      expect(article.votes).toBe(0);
+      expect(article.author).toBe("butter_bridge");
+      expect(article.body).toBe("I find this existence challenging");
+      expect(article.votes).toBe(100);
       expect(article.article_img_url).toBe(
         "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       );
-      expect(article.created_at).toBe("2020-10-16T05:03:00.000Z");
+      expect(article.created_at).toBe("2020-07-09T20:11:00.000Z");
+      expect(article.comment_count).toBe(11);
     });
     describe("💥 Error handling tests", () => {
       test("Returns 404 when the id is not found", async () => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -65,7 +65,8 @@
         "body": "Call me Mitchell. Some years ago..",
         "votes": 0,
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-        "created_at": "2020-10-16T05:03:00.000Z"
+        "created_at": "2020-10-16T05:03:00.000Z",
+        "comment_count": 0
       }
     }
   },

--- a/models/articleModels.js
+++ b/models/articleModels.js
@@ -31,7 +31,7 @@ const selectAllArticles = async (
   }
 
   let queryStr = `SELECT a.author, a.title, a.article_id, a.topic, a.created_at,a.votes, a.article_img_url,
-  COUNT(c.comment_id) AS comment_count
+  CAST(COUNT(c.comment_id) AS integer) AS comment_count
   FROM articles a
   LEFT JOIN comments c ON a.article_id = c.article_id`;
 
@@ -63,9 +63,15 @@ const selectAllArticles = async (
 
 const selectArticleById = async (article_id) => {
   const {rows} = await db.query(
-    `SELECT * FROM articles WHERE article_id = $1`,
+    `SELECT a.author, a.title, a.article_id, a.topic, a.created_at, a.votes, a.article_img_url, a.body,
+    CAST(COUNT(c.comment_id) AS integer) AS comment_count
+     FROM articles a
+     LEFT JOIN comments c ON a.article_id = c.article_id
+     WHERE a.article_id = $1
+     GROUP BY a.article_id`,
     [article_id]
   );
+
   const article = rows[0];
   if (!article) {
     return Promise.reject({
@@ -73,6 +79,7 @@ const selectArticleById = async (article_id) => {
       msg: "Article not found",
     });
   }
+
   return article;
 };
 


### PR DESCRIPTION
- Modified the `GET /api/articles/:article_id` endpoint to include `comment_count`.
- Updated SQL query to use `LEFT JOIN` with the `comments` table to count related comments for each article.
- Ensured that `comment_count` is returned as an integer, reflecting the total number of comments.
- Updated endpoints.json file to include comment_count