### PR TITLE
feat: add POST /api/topics endpoint with error handling

### DIFF
--- a/__tests__/integration/topics.test.js
+++ b/__tests__/integration/topics.test.js
@@ -18,5 +18,54 @@ describe("GET: /api/topics", () => {
     });
   });
 });
+describe("POST: /api/topics", () => {
+  test("Responds with a 201 status when topic is created successfully", async () => {
+    const testTopic = {slug: "topic name", description: "test description"};
+    await request(app).post("/api/topics").send(testTopic).expect(201);
+  });
+  test("Returns newly created topic", async () => {
+    const testNewTopic = {
+      slug: "coding",
+      description: "Learn more about JavaScript",
+      img_url: "https://blog.pango.education/hubfs/Coding%20Blog%20Image.jpg",
+    };
+    const {
+      body: {newTopic},
+    } = await request(app).post("/api/topics").send(testNewTopic).expect(201);
+    expect(newTopic.slug).toBe("coding");
+    expect(newTopic.description).toBe("Learn more about JavaScript");
+    expect(newTopic.img_url).toBe(
+      "https://blog.pango.education/hubfs/Coding%20Blog%20Image.jpg"
+    );
+  });
+  describe("", () => {
+    test("Responds with 400 bad request if required fields are missing", async () => {
+      const incompleteTopic = {
+        slug: "coding",
+      };
+      const {
+        body: {msg},
+      } = await request(app)
+        .post("/api/topics")
+        .send(incompleteTopic)
+        .expect(400);
+      expect(msg).toBe("Bad Request: Missing required fields");
+    });
+    test("Returns 400 for invalid data types", async () => {
+      const invalidTopic = {
+        slug: 123,
+        description: "Learn more about JavaScript",
+        img_url: "https://blog.pango.education/hubfs/Coding%20Blog%20Image.jpg",
+      };
+      const {
+        body: {msg},
+      } = await request(app).post("/api/topics").send(invalidTopic).expect(400);
+      expect(msg).toBe("Bad Request: Invalid data type");
+    });
+  });
+});
+
+
+
 
 

--- a/controllers/topicControllers.js
+++ b/controllers/topicControllers.js
@@ -1,4 +1,4 @@
-const {selectAllTopics} = require("../models/topicModels");
+const {selectAllTopics, insertTopic} = require("../models/topicModels");
 
 const getAllTopics = async (req, res, next) => {
   try {
@@ -9,4 +9,14 @@ const getAllTopics = async (req, res, next) => {
   }
 };
 
-module.exports = getAllTopics;
+const postTopic = async (req, res, next) => {
+  try {
+    const {slug, description, img_url} = req.body;
+    const newTopic = await insertTopic(slug, description, img_url);
+    res.status(201).send({newTopic});
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = {getAllTopics, postTopic};

--- a/endpoints.json
+++ b/endpoints.json
@@ -9,6 +9,22 @@
       "topics": [{"slug": "football", "description": "Footie!"}]
     }
   },
+  "POST /api/topics": {
+    "description": "Creates a new topic",
+    "queries": [],
+    "exampleRequest": {
+      "slug": "coding",
+      "description": "Learn more about JavaScript",
+      "img_url": "https://blog.pango.education/hubfs/Coding%20Blog%20Image.jpg"
+    },
+    "exampleResponse": {
+      "newTopic": {
+        "slug": "coding",
+        "description": "Learn more about JavaScript",
+        "img_url": "https://blog.pango.education/hubfs/Coding%20Blog%20Image.jpg"
+      }
+    }
+  },
   "GET /api/users": {
     "description": "retrieves all users",
     "queries": [],

--- a/models/topicModels.js
+++ b/models/topicModels.js
@@ -18,5 +18,26 @@ const selectTopicBySlug = async (topic) => {
   return rows[0];
 };
 
-module.exports = {selectAllTopics, selectTopicBySlug};
+const insertTopic = async (slug, description, img_url) => {
+  if (!slug || !description) {
+    return Promise.reject({
+      status: 400,
+      msg: "Bad Request: Missing required fields",
+    });
+  }
+
+  if (typeof slug !== "string" || typeof description !== "string") {
+    return Promise.reject({
+      status: 400,
+      msg: "Bad Request: Invalid data type",
+    });
+  }
+  const queryStr = `INSERT INTO topics (slug, description, img_url) VALUES ($1, $2, $3) RETURNING *`;
+  const { rows } = await db.query(queryStr, [slug, description, img_url]);
+  return rows[0];
+};
+
+module.exports = {selectAllTopics, selectTopicBySlug, insertTopic};
+
+
 

--- a/routers/topicsRouter.js
+++ b/routers/topicsRouter.js
@@ -1,8 +1,9 @@
 const express = require("express");
-const getAllTopics = require("../controllers/topicControllers");
+const { getAllTopics, postTopic } = require("../controllers/topicControllers");
 
 const topicsRouter = express.Router();
 
-topicsRouter.route("/").get(getAllTopics);
+topicsRouter.route("/").get(getAllTopics).post(postTopic);
 
 module.exports = topicsRouter;
+


### PR DESCRIPTION
- Implemented `insertTopic` in model to insert new topics into the database.
- Created `postTopic` controller with `next` for error handling.
- Added `POST /api/topics` route to router.
- Updated API documentation in `endpoints.json`.
- Wrote tests to verify topic creation, missing fields, and invalid data handling.